### PR TITLE
add llama-3.3-70b-specdec model

### DIFF
--- a/llm_groq.py
+++ b/llm_groq.py
@@ -126,7 +126,7 @@ class LLMGroq(llm.Model):
         )
         if stream:
             for chunk in resp:
-                if chunk.choices[0] and chunk.choices[0].delta:
+                if chunk.choices[0] and chunk.choices[0].delta.content:
                     yield from chunk.choices[0].delta.content
         else:
             yield from resp.choices[0].message.content

--- a/llm_groq.py
+++ b/llm_groq.py
@@ -1,5 +1,3 @@
-# [LLM](https://llm.datasette.io/) plugin providing access to [Groqcloud](http://console.groq.com) models.
-# Base off of llm-mistral (https://github.com/simonw/llm-mistral)
 import llm
 from groq import Groq
 from pydantic import Field

--- a/llm_groq.py
+++ b/llm_groq.py
@@ -17,6 +17,7 @@ def register_models(register):
     register(LLMGroq("groq-mixtral"))
     register(LLMGroq("groq-gemma"))
     register(LLMGroq("groq-gemma2"))
+    register(LLMGroq("groq-llama-3.3-70b"))
 
 
 class LLMGroq(llm.Model):
@@ -32,6 +33,7 @@ class LLMGroq(llm.Model):
         "groq-llama3.1-8b": "llama-3.1-8b-instant",
         "groq-llama3.1-70b": "llama-3.1-70b-versatile",
         "groq-llama3.1-405b": "llama-3.1-405b-reasoning",
+        "groq-llama-3.3-70b": "llama-3.3-70b-versatile",
     }
 
     class Options(llm.Options):
@@ -124,7 +126,10 @@ class LLMGroq(llm.Model):
         )
         if stream:
             for chunk in resp:
-                if chunk.choices[0].delta.content:
-                    yield from chunk.choices[0].delta.content
+                try:
+                    if chunk.choices[0].delta.content:
+                        yield from chunk.choices[0].delta.content
+                except TypeError:
+                    breakpoint()
         else:
             yield from resp.choices[0].message.content

--- a/llm_groq.py
+++ b/llm_groq.py
@@ -126,10 +126,7 @@ class LLMGroq(llm.Model):
         )
         if stream:
             for chunk in resp:
-                try:
-                    if chunk.choices[0].delta.content:
-                        yield from chunk.choices[0].delta.content
-                except TypeError:
-                    breakpoint()
+                if chunk.choices[0] and chunk.choices[0].delta:
+                    yield from chunk.choices[0].delta.content
         else:
             yield from resp.choices[0].message.content

--- a/llm_groq.py
+++ b/llm_groq.py
@@ -16,7 +16,7 @@ def register_models(register):
     register(LLMGroq("groq-gemma"))
     register(LLMGroq("groq-gemma2"))
     register(LLMGroq("groq-llama-3.3-70b"))
-
+    register(LLMGroq("groq-llama-3.3-70b-specdec"))
 
 class LLMGroq(llm.Model):
     can_stream = True
@@ -32,6 +32,7 @@ class LLMGroq(llm.Model):
         "groq-llama3.1-70b": "llama-3.1-70b-versatile",
         "groq-llama3.1-405b": "llama-3.1-405b-reasoning",
         "groq-llama-3.3-70b": "llama-3.3-70b-versatile",
+        "groq-llama-3.3-70b-specdec": "llama-3.3-70b-specdec",
     }
 
     class Options(llm.Options):


### PR DESCRIPTION
Supposedly [6x faster](https://groq.com/groq-first-generation-14nm-chip-just-got-a-6x-speed-boost-introducing-llama-3-1-70b-speculative-decoding-on-groqcloud/) with a [smaller context length](https://console.groq.com/docs/models)